### PR TITLE
binary_path_python no longer exists in recent Blender

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2,7 +2,11 @@
 import bpy
 from bpy.types import AddonPreferences
 
-PYPATH = bpy.app.binary_path_python
+if bpy.app.version >= (2, 91, 0):
+    PYPATH = sys.executable
+else:
+    PYPATH = bpy.app.binary_path_python
+
 import sverchok_open3d
 from sverchok.dependencies import draw_message
 from sverchok_open3d.dependencies import ex_dependencies, pip, ensurepip


### PR DESCRIPTION
resolves https://github.com/vicdoval/sverchok-open3d/issues/6